### PR TITLE
[*] fixed an exception when opening settings

### DIFF
--- a/src/Device/YeeLight/Artemis.Plugins.Devices.YeeLight/Views/YeeLightConfigurationDialogView.xaml
+++ b/src/Device/YeeLight/Artemis.Plugins.Devices.YeeLight/Views/YeeLightConfigurationDialogView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Artemis.Plugins.Devices.YeeLight.YeeLightConfigurationDialogView"
+﻿<UserControl x:Class="Artemis.Plugins.Devices.YeeLight.Views.YeeLightConfigurationDialogView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"


### PR DESCRIPTION
fixed an exception opening setting, naming inh XAML is bad for Stylenet
Stylet.StyletViewLocationException: Unable to find a View with type Artemis.Plugins.Devices.YeeLight.Views.YeeLightConfigurationDialogView
   at Stylet.ViewManager.LocateViewForModel(Type modelType)
   at Stylet.ViewManager.CreateViewForModel(Object model)
   at Stylet.ViewManager.CreateAndBindViewForModel(Object model)
   at Stylet.ViewManager.OnModelChanged(DependencyObject targetLocation, Object oldValue, Object newValue)
   at Stylet.Xaml.View.<>c.<.cctor>b__10_0(DependencyObject d, DependencyPropertyChangedEventArgs e)
   at System.Windows.FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   at System.Windows.DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
   at System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
   at System.Windows.DependencyObject.InvalidateProperty(DependencyProperty dp, Boolean preserveCurrentValue)
   at System.Windows.Data.BindingExpression.TransferValue(Object newValue, Boolean isASubPropertyChange)
   at System.Windows.Data.BindingExpression.Activate(Object item)
   at System.Windows.Data.BindingExpression.AttachToContext(AttachAttempt attempt)
   at System.Windows.Data.BindingExpression.MS.Internal.Data.IDataBindEngineClient.AttachToContext(Boolean lastChance)
   at MS.Internal.Data.DataBindEngine.Task.Run(Boolean lastChance)
   at MS.Internal.Data.DataBindEngine.Run(Object arg)
   at MS.Internal.Data.DataBindEngine.OnLayoutUpdated(Object sender, EventArgs e)
   at System.Windows.ContextLayoutManager.fireLayoutUpdateEvent()
   at System.Windows.ContextLayoutManager.UpdateLayout()
at System.Windows.Interop.HwndSource.SetLayoutSize()
   at System.Windows.Interop.HwndSource.set_RootVisualInternal(Visual value)
   at System.Windows.Interop.HwndSource.set_RootVisual(Visual value)
   at System.Windows.Window.SetRootVisual()
   at System.Windows.Window.SetRootVisualAndUpdateSTC()
   at System.Windows.Window.SetupInitialState(Double requestedTop, Double requestedLeft, Double requestedWidth, Double requestedHeight)
   at System.Windows.Window.CreateSourceWindow(Boolean duringShow)
   at System.Windows.Window.CreateSourceWindowDuringShow()
   at System.Windows.Window.SafeCreateWindowDuringShow()
   at System.Windows.Window.ShowHelper(Object booleanBox)
   at System.Windows.Window.Show()
   at Stylet.WindowManager.ShowWindow(Object viewModel, IViewAware ownerViewModel)
   at Stylet.WindowManager.ShowWindow(Object viewModel)
   at Artemis.UI.Screens.Settings.Tabs.Plugins.PluginSettingsViewModel.OpenSettings() in C:\Hobby\Rival_Artemis-RGB\Artemis\src\Artemis.UI\Screens\Settings\Tabs\Plugins\PluginSettingsViewModel.cs:line 102